### PR TITLE
Remove unnecessary import

### DIFF
--- a/common/prisma/src/prisma.module.ts
+++ b/common/prisma/src/prisma.module.ts
@@ -3,7 +3,6 @@ import { PrismaService } from './adapters/prisma.service';
 
 @Global()
 @Module({
-  imports: [PrismaService],
   providers: [PrismaService],
   exports: [PrismaService],
 })


### PR DESCRIPTION
Imports are for modules. The `PrismaService` is already provided in `providers`